### PR TITLE
allow train.py to resume non-lora models

### DIFF
--- a/train.py
+++ b/train.py
@@ -163,11 +163,7 @@ elif init_from == 'resume':
     # force these config attributes to be equal otherwise we can't even resume training
     # the rest of the attributes (e.g. dropout) can stay as desired from command line
     for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size', 'lora_rank', 'lora_alpha']:
-        try:
-            model_args[k] = checkpoint_model_args[k]
-        except KeyError as ex:
-            if k in [ 'lora_rank', 'lora_alpha' ]:
-                model_args[k] = 0 # allow resuming models that didn't include lora
+        model_args[k] = checkpoint_model_args.get(k, 0)
     # create the model
 
     # LoRA fine-tuning?    

--- a/train.py
+++ b/train.py
@@ -163,7 +163,11 @@ elif init_from == 'resume':
     # force these config attributes to be equal otherwise we can't even resume training
     # the rest of the attributes (e.g. dropout) can stay as desired from command line
     for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size', 'lora_rank', 'lora_alpha']:
-        model_args[k] = checkpoint_model_args[k]
+        try:
+            model_args[k] = checkpoint_model_args[k]
+        except KeyError as ex:
+            if k in [ 'lora_rank', 'lora_alpha' ]:
+                model_args[k] = 0 # allow resuming models that didn't include lora
     # create the model
 
     # LoRA fine-tuning?    


### PR DESCRIPTION
Many models will have been created with the default nanogpt code, which doesn't include lora_rank or lora_alpha parameters.  This change just sets them to zero.  Otherwise train.py crashes with a KeyError (lora_rank not found).